### PR TITLE
Fix regexp

### DIFF
--- a/docs/migrate-odoo-12-to-13.rst
+++ b/docs/migrate-odoo-12-to-13.rst
@@ -18,7 +18,7 @@ New API
     
     # remove deprecated decorators
     # https://github.com/odoo/odoo/commit/c552fb7a618afe2feea2e0358ead9eb6ebff0c94
-    find . -type f -name '*.py' | xargs sed -i '/@api.model_cr/d'
+    find . -type f -name '*.py' | xargs sed -i '/@api.model_cr$/d'
     find . -type f -name '*.py' | xargs sed -i '/@api.v8/d'
     find . -type f -name '*.py' | xargs sed -i '/@api.model_cr_context/d'
     find . -type f -name '*.py' | xargs sed -i '/@api.noguess/d'


### PR DESCRIPTION
Previous regexp also deletes @api.model_create_multi decorators which, as I understand it, do not need to be deleted